### PR TITLE
Port PotPlayer ChatGPT translator to VLC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,66 @@
-# VLC_Ollama_Translate
-The VLC-version of PotPlayer_ChatGPT_Translate
+# VLC Ollama Translate
+
+VLC Ollama Translate is a full port of the
+[PotPlayer ChatGPT Translate](https://github.com/Felix3322/PotPlayer_ChatGPT_Translate)
+plugin.  It brings the same real-time, context aware subtitle translation
+experience to VLC by combining a Python backend with a native VLC Lua
+extension.  The project keeps all of the features of the original
+plugin, including:
+
+- ChatGPT/Responses compatible translation pipeline with context
+  caching and smart trimming.
+- Model, API URL, retry and delay configuration compatible with the
+  original PotPlayer installer.
+- Language selection identical to the AngleScript version, including
+  proper handling for RTL output.
+- Token budget heuristics and customisable limits for different
+  models.
+- Integration with VLC through a GUI extension that mirrors the
+  PotPlayer control panel.
+
+## Project structure
+
+- `vlc_ollama_translate/` – Python package that implements the
+  translation engine, configuration handling, model heuristics and CLI
+  tooling.
+- `lua/extensions/chatgpt_translate.lua` – VLC Lua extension that
+  exposes the user interface, persists configuration and executes the
+  translator.
+- `pyproject.toml` – Package metadata with an entry point named
+  `vlc-ollama-translate` used by both the command line interface and
+  the Lua extension.
+
+## Installation
+
+1. Install the Python package in your VLC environment:
+
+   ```bash
+   pip install .
+   ```
+
+2. Copy `lua/extensions/chatgpt_translate.lua` into your VLC extensions
+   directory (e.g. `%APPDATA%\vlc\lua\extensions` on Windows or
+   `~/.local/share/vlc/lua/extensions` on Linux).
+
+3. Launch VLC and enable the *ChatGPT Translate* extension from the
+   `View` menu.
+
+## Usage
+
+1. Open the *ChatGPT Translate* panel in VLC.
+2. Enter your model/API configuration in the same `model|url|nullkey|delay|retry|cache`
+   format used by the PotPlayer plugin and provide an API key if
+   required.
+3. Choose the source and target languages.
+4. Provide a subtitle file path or allow the tool to generate an output
+   file next to the original.
+5. Click **Translate** to create a translated subtitle track.  The
+   translation reuses the PotPlayer prompts and context management,
+   ensuring identical output quality.
+
+You can also drive the backend from the command line:
+
+```bash
+vlc-ollama-translate configure --api-key sk-... --model gpt-4o
+vlc-ollama-translate translate --input input.srt --output translated.srt --include-original
+```

--- a/lua/extensions/chatgpt_translate.lua
+++ b/lua/extensions/chatgpt_translate.lua
@@ -1,0 +1,234 @@
+--[[
+ChatGPT Translate VLC extension.
+
+This script provides a lightweight user interface that mirrors the
+PotPlayer ChatGPT Translate plugin.  It exposes the most important
+configuration options and calls the Python translation backend shipped
+with this repository.
+--]]
+
+local languages = {
+  "",
+  "af", "sq", "am", "ar", "hy", "az", "eu", "be", "bn", "bs", "bg", "ca", "ceb", "ny", "zh-CN",
+  "zh-TW", "co", "hr", "cs", "da", "nl", "en", "eo", "et", "tl", "fi", "fr", "fy", "gl", "ka",
+  "de", "el", "gu", "ht", "ha", "haw", "he", "hi", "hmn", "hu", "is", "ig", "id", "ga", "it",
+  "ja", "jw", "kn", "kk", "km", "ko", "ku", "ky", "lo", "la", "lv", "lt", "lb", "mk", "ms",
+  "mg", "ml", "mt", "mi", "mr", "mn", "my", "ne", "no", "or", "ps", "fa", "pl", "pt", "pa", "ro",
+  "ru", "sm", "gd", "sr", "st", "sn", "sd", "si", "sk", "sl", "so", "es", "su", "sw", "sv", "tg",
+  "ta", "te", "th", "tr", "uk", "ur", "ug", "uz", "vi", "cy", "xh", "yi", "yo", "zu"
+}
+
+local dlg = nil
+local widgets = {}
+local current_config = {}
+
+local function escape_arg(text)
+  if not text or text == "" then
+    return "''"
+  end
+  local escaped = string.gsub(text, "'", "'\\''")
+  return "'" .. escaped .. "'"
+end
+
+local function run_command(cmd)
+  vlc.msg.dbg("ChatGPT Translate executing: " .. cmd)
+  local handle = io.popen(cmd .. " 2>&1")
+  if not handle then
+    return false, "Failed to spawn helper command"
+  end
+  local output = handle:read("*a") or ""
+  output = string.gsub(output, "%s+$", "")
+  local success, _, code = handle:close()
+  if success == nil then
+    success = false
+  end
+  if success then
+    return true, output
+  end
+  local reason = output
+  if reason == "" and code then
+    reason = "exit code " .. tostring(code)
+  end
+  return false, reason
+end
+
+local function load_config()
+  local ok, output = run_command("vlc-ollama-translate show-config")
+  local config = {}
+  if not ok then
+    return config
+  end
+  for line in string.gmatch(output, "[^\n]+") do
+    local key, value = string.match(line, "([^=]+)=(.*)")
+    if key and value then
+      config[key] = value
+    end
+  end
+  return config
+end
+
+local function build_login_value(config)
+  local parts = {}
+  local model = config["selected_model"] or ""
+  if model ~= "" then
+    table.insert(parts, model)
+  end
+  if config["api_url"] and config["api_url"] ~= "" then
+    table.insert(parts, config["api_url"])
+  end
+  if (config["api_key"] or "") == "" then
+    table.insert(parts, "nullkey")
+  end
+  if config["delay_ms"] and config["delay_ms"] ~= "0" then
+    table.insert(parts, config["delay_ms"])
+  end
+  if config["retry_mode"] and config["retry_mode"] ~= "0" then
+    table.insert(parts, "retry" .. config["retry_mode"])
+  end
+  if config["context_cache_mode"] and config["context_cache_mode"] ~= "" then
+    table.insert(parts, "cache=" .. config["context_cache_mode"])
+  end
+  return table.concat(parts, "|")
+end
+
+local function populate_dropdown(dropdown, value)
+  if not dropdown then return end
+  for _, lang in ipairs(languages) do
+    local label = lang
+    if lang == "" then
+      label = "Auto"
+    end
+    dropdown:add_value(label, lang)
+  end
+  if dropdown.set_value then
+    if value and value ~= "" then
+      dropdown:set_value(value)
+    else
+      dropdown:set_value("")
+    end
+  end
+end
+
+local function show_status(message)
+  if widgets.status then
+    widgets.status:set_text(message)
+  else
+    vlc.msg.dbg("ChatGPT Translate: " .. message)
+  end
+end
+
+local function save_configuration()
+  local login = widgets.login:get_text()
+  local api_key = widgets.api_key and widgets.api_key:get_text() or ""
+  local source = widgets.source and widgets.source:get_value() or ""
+  local target = widgets.target and widgets.target:get_value() or ""
+  local args = {
+    "vlc-ollama-translate", "configure",
+    "--login-string", login,
+    "--api-key", api_key,
+    "--source-language", source,
+    "--target-language", target,
+  }
+  local cmd = {}
+  for _, value in ipairs(args) do
+    table.insert(cmd, escape_arg(value))
+  end
+  local ok, output = run_command(table.concat(cmd, " "))
+  if ok then
+    current_config = load_config()
+    if widgets.login and widgets.login.set_text then
+      widgets.login:set_text(build_login_value(current_config))
+    end
+    if widgets.source and widgets.source.set_value then
+      widgets.source:set_value(current_config["source_language"] or "")
+    end
+    if widgets.target and widgets.target.set_value then
+      widgets.target:set_value(current_config["target_language"] or "en")
+    end
+    show_status("Configuration saved")
+  else
+    show_status("Failed to save configuration: " .. output)
+  end
+end
+
+local function translate_subtitles()
+  local input_path = widgets.subtitle_path:get_text()
+  if not input_path or input_path == "" then
+    show_status("Please provide an input subtitle path")
+    return
+  end
+  local output_path = widgets.output_path:get_text()
+  if not output_path or output_path == "" then
+    output_path = input_path .. ".translated.srt"
+  end
+  local args = {
+    "vlc-ollama-translate", "translate",
+    "--input", input_path,
+    "--output", output_path,
+    "--include-original",
+  }
+  if widgets.api_key:get_text() ~= "" then
+    table.insert(args, "--api-key")
+    table.insert(args, widgets.api_key:get_text())
+  end
+  local cmd = {}
+  for _, value in ipairs(args) do
+    table.insert(cmd, escape_arg(value))
+  end
+  local ok, output = run_command(table.concat(cmd, " "))
+  if ok then
+    show_status(output)
+  else
+    show_status("Translation failed: " .. output)
+  end
+end
+
+local function create_dialog()
+  dlg = vlc.dialog("ChatGPT Translate")
+  widgets.login_label = dlg:add_label("Model | URL | nullkey | delay | retry | cache", 1, 1, 3, 1)
+  widgets.login = dlg:add_text_input(build_login_value(current_config), 1, 2, 3, 1)
+  widgets.api_label = dlg:add_label("API Key", 1, 3, 1, 1)
+  widgets.api_key = dlg:add_text_input(current_config["api_key"] or "", 1, 4, 3, 1)
+  widgets.source_label = dlg:add_label("Source language", 1, 5, 1, 1)
+  widgets.source = dlg:add_dropdown(1, 6, 1, 1)
+  widgets.target_label = dlg:add_label("Target language", 2, 5, 1, 1)
+  widgets.target = dlg:add_dropdown(2, 6, 1, 1)
+  populate_dropdown(widgets.source, current_config["source_language"])
+  populate_dropdown(widgets.target, current_config["target_language"] or "en")
+  widgets.save_btn = dlg:add_button("Save configuration", save_configuration, 3, 6, 1, 1)
+
+  widgets.subtitle_label = dlg:add_label("Subtitle file (SRT)", 1, 7, 1, 1)
+  widgets.subtitle_path = dlg:add_text_input("", 1, 8, 3, 1)
+  widgets.output_label = dlg:add_label("Output path", 1, 9, 1, 1)
+  widgets.output_path = dlg:add_text_input("", 1, 10, 3, 1)
+  widgets.translate_btn = dlg:add_button("Translate", translate_subtitles, 3, 10, 1, 1)
+  widgets.status = dlg:add_label("", 1, 11, 3, 1)
+end
+
+function descriptor()
+  return {
+    title = "ChatGPT Translate",
+    version = "1.0",
+    author = "ChatGPT",
+    shortdesc = "ChatGPT subtitle translation",
+    description = "Translate subtitles through ChatGPT compatible APIs",
+  }
+end
+
+function activate()
+  current_config = load_config()
+  create_dialog()
+  show_status("Ready")
+end
+
+function deactivate()
+  if dlg then
+    dlg:delete()
+  end
+  dlg = nil
+  widgets = {}
+end
+
+function close()
+  deactivate()
+end

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[build-system]
+requires = ["setuptools>=65"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "vlc-ollama-translate"
+version = "0.1.0"
+description = "VLC port of the PotPlayer ChatGPT Translate plugin"
+authors = [{name = "ChatGPT", email = ""}]
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: MIT License",
+]
+
+[project.scripts]
+vlc-ollama-translate = "vlc_ollama_translate.__main__:main"

--- a/vlc_ollama_translate/__init__.py
+++ b/vlc_ollama_translate/__init__.py
@@ -1,0 +1,12 @@
+"""VLC Ollama Translate package."""
+
+from .config import PluginConfig, load_config, save_config
+from .translator import SubtitleTranslator, TranslationResult
+
+__all__ = [
+    "PluginConfig",
+    "load_config",
+    "save_config",
+    "SubtitleTranslator",
+    "TranslationResult",
+]

--- a/vlc_ollama_translate/__main__.py
+++ b/vlc_ollama_translate/__main__.py
@@ -1,0 +1,162 @@
+"""Command line entry point for VLC Ollama Translate."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import List
+
+from .api_client import APIError
+from .config import PluginConfig, load_config, save_config
+from .languages import LANGUAGES
+from .model_limits import get_model_max_tokens
+from .subtitle import parse_srt
+from .translator import SubtitleTranslator
+
+
+def _validate_language(code: str) -> str:
+    if code not in LANGUAGES:
+        raise SystemExit(f"Unsupported language code: {code}")
+    return code
+
+
+def cmd_configure(args: argparse.Namespace) -> None:
+    cfg = load_config()
+    if args.login_string:
+        cfg.update_from_login_string(args.login_string)
+    if args.api_key is not None:
+        cfg.api_key = args.api_key
+    if args.model is not None:
+        cfg.selected_model = args.model
+    if args.api_url is not None:
+        cfg.api_url = args.api_url
+    if args.delay_ms is not None:
+        cfg.delay_ms = args.delay_ms
+    if args.retry_mode is not None:
+        cfg.retry_mode = args.retry_mode
+    if args.context_budget is not None:
+        cfg.context_token_budget = args.context_budget
+    if args.truncation_mode is not None:
+        cfg.context_truncation_mode = args.truncation_mode
+    if args.cache_mode is not None:
+        cfg.context_cache_mode = args.cache_mode
+    if args.source_language is not None:
+        cfg.source_language = args.source_language
+    if args.target_language is not None:
+        cfg.target_language = args.target_language
+    cfg.save()
+    print("Configuration updated", file=sys.stderr)
+
+
+def cmd_show_config(args: argparse.Namespace) -> None:
+    cfg = load_config()
+    data = cfg.to_dict()
+    for key in sorted(data):
+        value = data[key]
+        if isinstance(value, dict):
+            import json
+
+            print(f"{key}={json.dumps(value, ensure_ascii=False)}")
+        else:
+            print(f"{key}={value}")
+
+
+def _format_block(index: int, start: str, end: str, lines: List[str]) -> str:
+    block_lines = [str(index), f"{start} --> {end}"] + lines + [""]
+    return "\n".join(block_lines)
+
+
+def cmd_translate(args: argparse.Namespace) -> None:
+    cfg = load_config()
+    if args.api_key:
+        cfg.api_key = args.api_key
+    if not cfg.api_key and args.require_key:
+        raise SystemExit("API key not configured. Use the configure command or pass --api-key.")
+    if args.source_language:
+        cfg.source_language = _validate_language(args.source_language)
+    if args.target_language:
+        cfg.target_language = _validate_language(args.target_language)
+    cfg.normalise_languages()
+
+    input_path = Path(args.input).expanduser().resolve()
+    output_path = Path(args.output).expanduser().resolve()
+
+    if not input_path.exists():
+        raise SystemExit(f"Input subtitle file does not exist: {input_path}")
+
+    content = input_path.read_text(encoding="utf-8")
+    entries = parse_srt(content)
+    if not entries:
+        raise SystemExit("No subtitle entries found in the input file")
+
+    max_tokens = get_model_max_tokens(cfg)
+    translator = SubtitleTranslator(cfg, max_tokens)
+    translated_blocks: List[str] = []
+    index = 1
+    for entry in entries:
+        text = entry.normalised_text()
+        if not text:
+            continue
+        try:
+            result = translator.translate(text)
+        except APIError as exc:
+            raise SystemExit(f"Translation failed: {exc}")
+        if args.include_original:
+            lines = entry.normalised_text().splitlines()
+            lines.append(result.translated)
+        else:
+            lines = [result.translated]
+        translated_blocks.append(_format_block(index, entry.start, entry.end, lines))
+        index += 1
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text("\n".join(translated_blocks), encoding="utf-8")
+    print(f"Translated subtitles written to {output_path}")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="VLC Ollama Translate utility")
+    subparsers = parser.add_subparsers(dest="command")
+
+    configure = subparsers.add_parser("configure", help="Update stored configuration")
+    configure.add_argument("--login-string", help="PotPlayer style configuration string", default="")
+    configure.add_argument("--api-key")
+    configure.add_argument("--model")
+    configure.add_argument("--api-url")
+    configure.add_argument("--delay-ms", type=int)
+    configure.add_argument("--retry-mode", type=int)
+    configure.add_argument("--context-budget", type=int)
+    configure.add_argument("--truncation-mode", choices=["drop_oldest", "smart_trim"])
+    configure.add_argument("--cache-mode", choices=["auto", "off"])
+    configure.add_argument("--source-language")
+    configure.add_argument("--target-language")
+    configure.set_defaults(func=cmd_configure)
+
+    show_cfg = subparsers.add_parser("show-config", help="Print the current configuration")
+    show_cfg.set_defaults(func=cmd_show_config)
+
+    translate = subparsers.add_parser("translate", help="Translate a subtitle file")
+    translate.add_argument("--input", required=True, help="Path to the subtitle file (SRT)")
+    translate.add_argument("--output", required=True, help="Output path for the translated SRT")
+    translate.add_argument("--include-original", action="store_true", help="Include original text above the translation")
+    translate.add_argument("--api-key", help="Override API key for this run")
+    translate.add_argument("--source-language", help="Override the configured source language")
+    translate.add_argument("--target-language", help="Override the configured target language")
+    translate.add_argument("--require-key", action="store_true", help="Fail if no API key is configured")
+    translate.set_defaults(func=cmd_translate)
+
+    return parser
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if not hasattr(args, "func"):
+        parser.print_help()
+        return
+    args.func(args)
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    main()

--- a/vlc_ollama_translate/api_client.py
+++ b/vlc_ollama_translate/api_client.py
@@ -1,0 +1,171 @@
+"""HTTP client wrapper that mirrors the PotPlayer plugin behaviour."""
+
+from __future__ import annotations
+
+import json
+import time
+from dataclasses import dataclass
+from typing import Dict, List, Optional
+from urllib import request, error
+
+
+@dataclass
+class APIError(Exception):
+    message: str
+    response: Optional[Dict] = None
+
+    def __str__(self) -> str:  # pragma: no cover - trivial wrapper
+        return self.message
+
+
+@dataclass
+class APIClient:
+    api_url: str
+    api_key: str
+    model: str
+    user_agent: str
+    delay_ms: int = 0
+    retry_mode: int = 0
+    context_cache_mode: str = "auto"
+
+    def _build_headers(self) -> Dict[str, str]:
+        headers = {
+            "User-Agent": self.user_agent,
+            "Content-Type": "application/json",
+        }
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def _request_with_retry(self, url: str, payload: Dict) -> Dict:
+        data = json.dumps(payload).encode("utf-8")
+        headers = self._build_headers()
+        attempts = 0
+        delay_seconds = max(0.0, self.delay_ms / 1000.0)
+
+        while True:
+            if attempts > 0:
+                # Retry behaviour: mode 0 -> no retry, mode 1 -> retry once,
+                # mode 2 -> infinite, mode 3 -> retry after delay for every
+                # attempt.  The PotPlayer plugin delays the initial attempt
+                # as well when retry mode is 3; we reproduce that behaviour
+                # here.
+                if self.retry_mode == 0 or (self.retry_mode == 1 and attempts > 1):
+                    break
+            if delay_seconds > 0 and (attempts == 0 and self.retry_mode == 3 or attempts > 0):
+                time.sleep(delay_seconds)
+            req = request.Request(url, data=data, headers=headers)
+            try:
+                with request.urlopen(req, timeout=60) as resp:
+                    body = resp.read().decode("utf-8")
+            except error.HTTPError as exc:
+                body = exc.read().decode("utf-8") if exc.fp else ""
+                try:
+                    parsed = json.loads(body)
+                except json.JSONDecodeError:
+                    parsed = {"error": {"message": body or exc.reason}}
+                raise APIError(parsed.get("error", {}).get("message", str(exc)), parsed)
+            except error.URLError as exc:
+                body = ""
+                parsed = {"error": {"message": getattr(exc, "reason", str(exc))}}
+            else:
+                try:
+                    parsed = json.loads(body)
+                except json.JSONDecodeError as exc:
+                    raise APIError(f"Failed to parse response JSON: {exc}") from exc
+                return parsed
+
+            attempts += 1
+            if self.retry_mode in (0, 1) and attempts > self.retry_mode:
+                raise APIError(parsed.get("error", {}).get("message", "Network error"), parsed)
+            # For retry modes 2 and 3, continue until success.
+
+    # --- Chat completions ---
+    def translate_chat(self, system_message: str, user_message: str, temperature: float = 0.0) -> str:
+        payload = {
+            "model": self.model,
+            "messages": [
+                {"role": "system", "content": system_message},
+                {"role": "user", "content": user_message},
+            ],
+            "max_tokens": 1000,
+            "temperature": temperature,
+        }
+        response = self._request_with_retry(self.api_url, payload)
+        try:
+            choices = response["choices"]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise APIError("Malformed response: missing 'choices' field", response) from exc
+        if not choices:
+            raise APIError("Empty response from the translation API", response)
+        message = choices[0].get("message", {})
+        content = message.get("content")
+        if not content:
+            raise APIError("Translation API returned no content", response)
+        return str(content)
+
+    # --- Responses endpoint with caching ---
+    def _derive_responses_url(self) -> Optional[str]:
+        url = self.api_url.rstrip("/")
+        if not url:
+            return None
+        if "/responses" in url:
+            return url
+        marker = "/chat/completions"
+        if marker in url:
+            return url.replace(marker, "/responses")
+        return f"{url}/responses"
+
+    def translate_responses(
+        self,
+        system_message: str,
+        instruction: str,
+        context_segments: List[str],
+        subtitle_text: str,
+        temperature: float = 0.0,
+    ) -> Optional[str]:
+        if self.context_cache_mode == "off":
+            return None
+        responses_url = self._derive_responses_url()
+        if not responses_url:
+            return None
+
+        content: List[Dict[str, str]] = [
+            {"type": "input_text", "text": system_message, "cache_control": {"type": "ephemeral"}},
+            {"type": "input_text", "text": instruction, "cache_control": {"type": "ephemeral"}},
+        ]
+        for segment in context_segments:
+            content.append(
+                {
+                    "type": "input_text",
+                    "text": f"Context entry (older to newer): {{{segment}}}",
+                    "cache_control": {"type": "ephemeral"},
+                }
+            )
+        content.append({"type": "input_text", "text": f"Subtitle to translate: {{{subtitle_text}}}"})
+
+        payload = {
+            "model": self.model,
+            "input": [
+                {"role": "system", "content": [content[0]]},
+                {"role": "user", "content": content[1:]},
+            ],
+            "max_output_tokens": 1000,
+            "temperature": temperature,
+        }
+        response = self._request_with_retry(responses_url, payload)
+        output = response.get("output")
+        if not isinstance(output, list):
+            # Fall back to chat endpoint.
+            return None
+        for entry in output:
+            if not isinstance(entry, dict):
+                continue
+            for part in entry.get("content", []):
+                if isinstance(part, dict) and part.get("type") == "output_text":
+                    text = part.get("text")
+                    if text:
+                        return str(text)
+                elif isinstance(part, str):
+                    return part
+        return None

--- a/vlc_ollama_translate/config.py
+++ b/vlc_ollama_translate/config.py
@@ -1,0 +1,178 @@
+"""Configuration management for the VLC Ollama Translate plugin.
+
+This module mirrors the behaviour of the PotPlayer ChatGPT plugin
+configuration system.  The PotPlayer version stored configuration
+values inside PotPlayer's registry like storage.  For the VLC port we
+persist the data on disk as JSON while keeping the same defaults and
+parsing logic so that the rest of the translation pipeline can be
+ported almost line-for-line.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+CONFIG_DIR = Path.home() / ".config" / "vlc_ollama_translate"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+
+DEFAULT_MODEL = "gpt-5-nano"
+DEFAULT_API_URL = "https://api.openai.com/v1/chat/completions"
+DEFAULT_DELAY_MS = 0
+DEFAULT_RETRY_MODE = 0
+DEFAULT_CONTEXT_TOKEN_BUDGET = 6000
+DEFAULT_CONTEXT_TRUNCATION_MODE = "drop_oldest"
+DEFAULT_CONTEXT_CACHE_MODE = "auto"
+DEFAULT_USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64)"
+
+# Matches the logic in the PotPlayer plugin where installer supplied
+# token rules can override defaults.  The structure mirrors
+# ``pre_model_token_limits_json`` which is a JSON object with two keys:
+# ``default`` and ``rules``.  ``rules`` is a list of dictionaries with
+# ``type`` (``prefix``/``contains``/``equals``), ``value`` and
+# ``tokens``.
+DEFAULT_TOKEN_LIMIT_RULES = {
+    "default": 4096,
+    "rules": [
+        {"type": "contains", "value": "gpt-4", "tokens": 8192},
+        {"type": "contains", "value": "gpt-4o", "tokens": 128000},
+        {"type": "contains", "value": "gpt-4.1", "tokens": 128000},
+        {"type": "contains", "value": "gpt-4o-mini", "tokens": 128000},
+        {"type": "contains", "value": "gpt-5", "tokens": 128000},
+        {"type": "contains", "value": "o1", "tokens": 128000},
+        {"type": "contains", "value": "gemini", "tokens": 122880},
+    ],
+}
+
+
+@dataclass
+class PluginConfig:
+    """Configuration container for the VLC port.
+
+    The fields intentionally mirror the names used by the PotPlayer
+    plugin so that the translation logic can be ported with minimal
+    changes.
+    """
+
+    api_key: str = ""
+    selected_model: str = DEFAULT_MODEL
+    api_url: str = DEFAULT_API_URL
+    delay_ms: int = DEFAULT_DELAY_MS
+    retry_mode: int = DEFAULT_RETRY_MODE
+    context_token_budget: int = DEFAULT_CONTEXT_TOKEN_BUDGET
+    context_truncation_mode: str = DEFAULT_CONTEXT_TRUNCATION_MODE
+    context_cache_mode: str = DEFAULT_CONTEXT_CACHE_MODE
+    model_token_limits: Dict[str, Any] = field(
+        default_factory=lambda: json.loads(json.dumps(DEFAULT_TOKEN_LIMIT_RULES))
+    )
+    user_agent: str = DEFAULT_USER_AGENT
+    source_language: str = ""
+    target_language: str = "en"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "api_key": self.api_key,
+            "selected_model": self.selected_model,
+            "api_url": self.api_url,
+            "delay_ms": self.delay_ms,
+            "retry_mode": self.retry_mode,
+            "context_token_budget": self.context_token_budget,
+            "context_truncation_mode": self.context_truncation_mode,
+            "context_cache_mode": self.context_cache_mode,
+            "model_token_limits": self.model_token_limits,
+            "user_agent": self.user_agent,
+            "source_language": self.source_language,
+            "target_language": self.target_language,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "PluginConfig":
+        cfg = cls()
+        for key, value in data.items():
+            if hasattr(cfg, key):
+                setattr(cfg, key, value)
+        # Normalise fields that should be integers.
+        cfg.delay_ms = int(cfg.delay_ms)
+        cfg.retry_mode = int(cfg.retry_mode)
+        cfg.context_token_budget = int(cfg.context_token_budget)
+        return cfg
+
+    def save(self, path: Optional[Path] = None) -> None:
+        if path is None:
+            path = CONFIG_FILE
+        if not path.parent.exists():
+            path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as fh:
+            json.dump(self.to_dict(), fh, indent=2, ensure_ascii=False)
+
+    @classmethod
+    def load(cls, path: Optional[Path] = None) -> "PluginConfig":
+        if path is None:
+            path = CONFIG_FILE
+        if not path.exists():
+            return cls()
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return cls.from_dict(data)
+
+    def update_from_login_string(self, login_string: str) -> None:
+        """Mimic the PotPlayer login parsing logic.
+
+        The login text in the PotPlayer plugin is in the form
+        ``model|api_url|nullkey|delay|retry|cache``.  ``nullkey`` tells
+        the plugin that the API does not require authentication.  We
+        reproduce the same behaviour so the documentation and user
+        expectations remain valid after porting to VLC.
+        """
+
+        tokens = [token.strip() for token in login_string.split("|") if token.strip()]
+        if not tokens:
+            return
+        self.selected_model = tokens[0]
+        for token in tokens[1:]:
+            lowered = token.lower()
+            if lowered.startswith("http://") or lowered.startswith("https://"):
+                self.api_url = token
+            elif lowered == "nullkey":
+                # Leaving api_key empty signals that authentication is not
+                # required.
+                self.api_key = ""
+            elif lowered.startswith("delay="):
+                try:
+                    self.delay_ms = int(lowered.split("=", 1)[1])
+                except ValueError:
+                    self.delay_ms = DEFAULT_DELAY_MS
+            elif lowered.startswith("retry"):
+                digits = ''.join(ch for ch in lowered if ch.isdigit())
+                if digits:
+                    self.retry_mode = int(digits)
+            elif lowered.startswith("cache="):
+                mode = token.split("=", 1)[1].strip().lower()
+                if mode in {"auto", "off", "disable", "disabled", "chat"}:
+                    self.context_cache_mode = "off" if mode != "auto" else "auto"
+                else:
+                    self.context_cache_mode = DEFAULT_CONTEXT_CACHE_MODE
+            elif lowered.isdigit():
+                value = int(lowered)
+                # Heuristic: values greater than 1000 are most likely a
+                # delay configuration; otherwise assume retry mode.
+                if value >= 1000:
+                    self.delay_ms = value
+                else:
+                    self.retry_mode = value
+
+    def normalise_languages(self) -> None:
+        if self.source_language in {"", "auto", "auto detect", "auto_detect"}:
+            self.source_language = ""
+        self.target_language = self.target_language or "en"
+
+
+def load_config() -> PluginConfig:
+    return PluginConfig.load()
+
+
+def save_config(cfg: PluginConfig) -> None:
+    cfg.save()

--- a/vlc_ollama_translate/context.py
+++ b/vlc_ollama_translate/context.py
@@ -1,0 +1,86 @@
+"""Context management utilities used by the translation pipeline."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List
+
+
+def estimate_token_count(text: str) -> int:
+    """Rudimentary token estimator.
+
+    The PotPlayer plugin divides the character length by four to
+    approximate the token usage which is good enough for budget
+    calculations.  We reuse the exact same heuristic here.
+    """
+
+    if not text:
+        return 0
+    return max(0, int(len(text) / 4))
+
+
+@dataclass
+class SubtitleHistory:
+    """Maintains recent subtitle lines for contextual translation."""
+
+    entries: List[str] = field(default_factory=list)
+
+    def add(self, subtitle: str) -> None:
+        if subtitle:
+            self.entries.append(subtitle)
+
+    def shrink(self, target: int) -> None:
+        if target < 0:
+            target = 0
+        if len(self.entries) > target:
+            del self.entries[0 : len(self.entries) - target]
+
+    def iter_recent(self) -> Iterable[str]:
+        return reversed(self.entries[:-1]) if len(self.entries) > 1 else []
+
+
+@dataclass
+class ContextWindow:
+    token_budget: int
+    truncation_mode: str = "drop_oldest"
+
+    def build_segments(self, history: SubtitleHistory, current_text: str, max_model_tokens: int) -> List[str]:
+        current_tokens = estimate_token_count(current_text)
+        safe_budget = max_model_tokens - 1000
+        if safe_budget < 0:
+            safe_budget = max_model_tokens
+        available = max(0, min(self.token_budget, max(0, safe_budget - current_tokens)))
+        use_smart_trim = self.truncation_mode.lower() == "smart_trim"
+
+        segments: List[str] = []
+        used_tokens = 0
+        for subtitle in history.iter_recent():
+            tokens = estimate_token_count(subtitle)
+            if tokens <= 0:
+                continue
+            if used_tokens + tokens <= available:
+                segments.insert(0, subtitle)
+                used_tokens += tokens
+            elif use_smart_trim and available > used_tokens:
+                remaining = available - used_tokens
+                char_budget = remaining * 4
+                if char_budget > 0:
+                    segments.insert(0, subtitle[-char_budget:])
+                break
+            else:
+                break
+        return segments
+
+    def shrink_history(self, history: SubtitleHistory) -> None:
+        history_budget = self.token_budget if self.token_budget > 0 else 0
+        history_target = int(history_budget / 16) if history_budget else 0
+        if history_target < 96:
+            history_target = 96
+        if history_target > 2048:
+            history_target = 2048
+        shrink_target = history_target - 64
+        if shrink_target < 64:
+            shrink_target = history_target // 2 if history_target else 0
+        if shrink_target < 32:
+            shrink_target = 32
+        history.shrink(shrink_target)

--- a/vlc_ollama_translate/languages.py
+++ b/vlc_ollama_translate/languages.py
@@ -1,0 +1,12 @@
+"""Language helpers mirroring the PotPlayer plugin."""
+
+LANGUAGES = [
+    "",
+    "af", "sq", "am", "ar", "hy", "az", "eu", "be", "bn", "bs", "bg", "ca", "ceb", "ny", "zh-CN",
+    "zh-TW", "co", "hr", "cs", "da", "nl", "en", "eo", "et", "tl", "fi", "fr", "fy", "gl", "ka",
+    "de", "el", "gu", "ht", "ha", "haw", "he", "hi", "hmn", "hu", "is", "ig", "id", "ga", "it",
+    "ja", "jw", "kn", "kk", "km", "ko", "ku", "ky", "lo", "la", "lv", "lt", "lb", "mk", "ms",
+    "mg", "ml", "mt", "mi", "mr", "mn", "my", "ne", "no", "or", "ps", "fa", "pl", "pt", "pa", "ro",
+    "ru", "sm", "gd", "sr", "st", "sn", "sd", "si", "sk", "sl", "so", "es", "su", "sw", "sv", "tg",
+    "ta", "te", "th", "tr", "uk", "ur", "ug", "uz", "vi", "cy", "xh", "yi", "yo", "zu",
+]

--- a/vlc_ollama_translate/model_limits.py
+++ b/vlc_ollama_translate/model_limits.py
@@ -1,0 +1,31 @@
+"""Model token limit helpers."""
+
+from __future__ import annotations
+
+from typing import Dict
+
+from .config import PluginConfig
+
+
+def get_model_max_tokens(config: PluginConfig) -> int:
+    rules = config.model_token_limits or {}
+    default = int(rules.get("default", 4096))
+    model_name = (config.selected_model or "").strip()
+    if not model_name:
+        return default
+
+    for entry in rules.get("rules", []):
+        if not isinstance(entry, dict):
+            continue
+        rule_type = entry.get("type")
+        value = entry.get("value", "")
+        limit = int(entry.get("tokens", 0) or 0)
+        if limit <= 0 or not value:
+            continue
+        if rule_type == "prefix" and model_name.startswith(value):
+            return limit
+        if rule_type == "contains" and value in model_name:
+            return limit
+        if rule_type == "equals" and model_name == value:
+            return limit
+    return default

--- a/vlc_ollama_translate/subtitle.py
+++ b/vlc_ollama_translate/subtitle.py
@@ -1,0 +1,50 @@
+"""Subtitle parsing helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import re
+from typing import Iterable, List
+
+
+SRT_BLOCK_RE = re.compile(
+    r"(?:^|\n)\s*\d+\s*\n"
+    r"(?P<start>\d\d:\d\d:\d\d,\d\d\d)\s+-->\s+"
+    r"(?P<end>\d\d:\d\d:\d\d,\d\d\d)\s*\n"
+    r"(?P<text>(?:.*?(?:\n|$))+?)"
+    r"(?=\n\s*\n|\Z)",
+    re.DOTALL,
+)
+
+
+@dataclass
+class SubtitleEntry:
+    start: str
+    end: str
+    text: str
+
+    def normalised_text(self) -> str:
+        return self.text.replace("\r", "").strip()
+
+
+def parse_srt(content: str) -> List[SubtitleEntry]:
+    entries: List[SubtitleEntry] = []
+    for match in SRT_BLOCK_RE.finditer(content):
+        text = match.group("text").strip()
+        if not text:
+            continue
+        entries.append(
+            SubtitleEntry(
+                start=match.group("start"),
+                end=match.group("end"),
+                text=text,
+            )
+        )
+    return entries
+
+
+def iter_dialogue_lines(entry: SubtitleEntry) -> Iterable[str]:
+    for line in entry.normalised_text().splitlines():
+        cleaned = line.strip()
+        if cleaned:
+            yield cleaned

--- a/vlc_ollama_translate/translator.py
+++ b/vlc_ollama_translate/translator.py
@@ -1,0 +1,124 @@
+"""High level translation service for VLC Ollama Translate."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from .api_client import APIClient, APIError
+from .config import PluginConfig
+from .context import ContextWindow, SubtitleHistory
+
+
+SYSTEM_PROMPT = (
+    "You are an expert subtitle translate tool with a deep understanding of both language and culture."
+    "Based on contextual clues, you provide translations that capture not only the literal meaning but also the nuanced metaphors,"
+    " euphemisms, and cultural symbols embedded in the dialogue."
+    "Your translations reflect the intended tone and cultural context, ensuring that every subtle reference and idiomatic expression"
+    " is accurately conveyed."
+    "I will provide you with some context for better translations, but DO NOT output any of them.\n"
+    "Rules:\n"
+    "1. Output the translation only.\n"
+    "2. Do NOT output extra comments or explanations.\n"
+    "3. Do NOT use any special characters or formatting in the translation."
+)
+
+CACHE_INSTRUCTION_TEMPLATE = (
+    "Translate the complete content under 'Subtitle to translate' using the provided context entries if available. "
+    "Each entry is shown as \"Context entry (older to newer): {...}\" and must never appear in the output.\n\n"
+    "Source language: {source}\n"
+    "Target language: {target}\n\n"
+    "Output only the translated subtitle without extra commentary."
+)
+
+USER_PROMPT_TEMPLATE = (
+    "Translate the complete content under the section 'Subtitle to translate' based on the section 'Subtitle context', if it exists.\n\n"
+    "Source language: {source}\n"
+    "Target language: {target}\n\n"
+    "[Subtitle context](DO NOT OUTPUT!):\n{{{context}}}\n\n"
+    "[Subtitle to translate]:\n{{{subtitle}}}"
+)
+
+
+@dataclass
+class TranslationResult:
+    original: str
+    translated: str
+
+
+class SubtitleTranslator:
+    def __init__(self, config: PluginConfig, max_model_tokens: int):
+        self.config = config
+        self.history = SubtitleHistory()
+        self.context_window = ContextWindow(
+            token_budget=config.context_token_budget,
+            truncation_mode=config.context_truncation_mode,
+        )
+        self.max_model_tokens = max_model_tokens
+        self.client = APIClient(
+            api_url=config.api_url,
+            api_key=config.api_key,
+            model=config.selected_model,
+            user_agent=config.user_agent,
+            delay_ms=config.delay_ms,
+            retry_mode=config.retry_mode,
+            context_cache_mode=config.context_cache_mode,
+        )
+        self._cache_failed = False
+
+    def _format_language(self, value: str, label: str) -> str:
+        if not value:
+            return label
+        return value
+
+    def _build_user_prompt(self, subtitle: str, context_segments: List[str], source: str, target: str) -> str:
+        context_text = "\n".join(context_segments) if context_segments else ""
+        user_prompt = USER_PROMPT_TEMPLATE.format(
+            source=source,
+            target=target,
+            context=context_text,
+            subtitle=subtitle,
+        )
+        if not context_segments:
+            user_prompt = user_prompt.replace("[Subtitle context](DO NOT OUTPUT!):\n{{{context}}}\n\n", "")
+        return user_prompt
+
+    def translate(self, subtitle: str) -> TranslationResult:
+        self.history.add(subtitle)
+        context_segments = self.context_window.build_segments(
+            self.history, subtitle, self.max_model_tokens
+        )
+        self.context_window.shrink_history(self.history)
+
+        source_label = self._format_language(self.config.source_language, "Auto Detect")
+        target_label = self._format_language(self.config.target_language, "Auto Detect")
+
+        user_prompt = self._build_user_prompt(subtitle, context_segments, source_label, target_label)
+        caching_instruction = CACHE_INSTRUCTION_TEMPLATE.format(
+            source=source_label,
+            target=target_label,
+        )
+
+        translation: Optional[str] = None
+        if self.config.context_cache_mode != "off" and not self._cache_failed:
+            try:
+                translation = self.client.translate_responses(
+                    SYSTEM_PROMPT,
+                    caching_instruction,
+                    context_segments,
+                    subtitle,
+                )
+            except APIError:
+                translation = None
+                self._cache_failed = True
+            else:
+                if translation is None:
+                    self._cache_failed = True
+
+        if translation is None:
+            translation = self.client.translate_chat(SYSTEM_PROMPT, user_prompt)
+
+        if self.config.target_language in {"fa", "ar", "he"}:
+            translation = "\u202B" + translation
+
+        return TranslationResult(original=subtitle, translated=translation.strip())


### PR DESCRIPTION
## Summary
- add a Python translation backend that mirrors the PotPlayer ChatGPT plugin configuration, token budgeting and context-aware prompts for VLC
- expose the translator via a CLI entry point and package metadata for easy installation
- integrate a VLC Lua extension that surfaces the configuration UI and translation workflow inside VLC and document usage in the README

## Testing
- python -m compileall vlc_ollama_translate

------
https://chatgpt.com/codex/tasks/task_e_68d6ee73d114832ca81e5815182ab993